### PR TITLE
0.24.1-ALPHA

### DIFF
--- a/allure.jupiter.bridge/src/main/java/ru/tinkoff/qa/neptune/allure/jupiter/bridge/ExcludeFromAllureReportExtension.java
+++ b/allure.jupiter.bridge/src/main/java/ru/tinkoff/qa/neptune/allure/jupiter/bridge/ExcludeFromAllureReportExtension.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 
 import java.lang.reflect.Method;
 
-import static ru.tinkoff.qa.neptune.allure.jupiter.bridge.NeptuneAllureExcludeTest.getCurrentTestClass;
 import static ru.tinkoff.qa.neptune.allure.lifecycle.ItemsToNotBeReported.excludeFixtureIfNecessary;
 import static ru.tinkoff.qa.neptune.allure.lifecycle.ItemsToNotBeReported.excludeTestResultIfNecessary;
 
@@ -19,9 +18,10 @@ public class ExcludeFromAllureReportExtension implements InvocationInterceptor {
 
     private <T> T checkCurrentLifeCycleItemAndProceed(Invocation<T> invocation,
                                                       ReflectiveInvocationContext<Method> invocationContext,
+                                                      ExtensionContext extensionContext,
                                                       boolean isTest) throws Throwable {
         var method = invocationContext.getExecutable();
-        var target = getCurrentTestClass();
+        var target = extensionContext.getRequiredTestClass();
 
         if (isTest) {
             excludeTestResultIfNecessary(target, method);
@@ -37,48 +37,48 @@ public class ExcludeFromAllureReportExtension implements InvocationInterceptor {
     public void interceptBeforeAllMethod(InvocationInterceptor.Invocation<Void> invocation,
                                          ReflectiveInvocationContext<Method> invocationContext,
                                          ExtensionContext extensionContext) throws Throwable {
-        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, false);
+        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, extensionContext, false);
     }
 
     @Override
     public void interceptAfterAllMethod(Invocation<Void> invocation,
                                         ReflectiveInvocationContext<Method> invocationContext,
                                         ExtensionContext extensionContext) throws Throwable {
-        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, false);
+        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, extensionContext, false);
     }
 
     @Override
     public void interceptBeforeEachMethod(InvocationInterceptor.Invocation<Void> invocation,
                                           ReflectiveInvocationContext<Method> invocationContext,
                                           ExtensionContext extensionContext) throws Throwable {
-        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, false);
+        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, extensionContext, false);
     }
 
     @Override
     public void interceptAfterEachMethod(Invocation<Void> invocation,
                                          ReflectiveInvocationContext<Method> invocationContext,
                                          ExtensionContext extensionContext) throws Throwable {
-        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, false);
+        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, extensionContext, false);
     }
 
     @Override
     public void interceptTestMethod(Invocation<Void> invocation,
                                     ReflectiveInvocationContext<Method> invocationContext,
                                     ExtensionContext extensionContext) throws Throwable {
-        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, true);
+        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, extensionContext, true);
     }
 
     @Override
     public <T> T interceptTestFactoryMethod(Invocation<T> invocation,
                                             ReflectiveInvocationContext<Method> invocationContext,
                                             ExtensionContext extensionContext) throws Throwable {
-        return checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, true);
+        return checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, extensionContext, true);
     }
 
     @Override
     public void interceptTestTemplateMethod(Invocation<Void> invocation,
                                             ReflectiveInvocationContext<Method> invocationContext,
                                             ExtensionContext extensionContext) throws Throwable {
-        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, true);
+        checkCurrentLifeCycleItemAndProceed(invocation, invocationContext, extensionContext, true);
     }
 }

--- a/allure.jupiter.bridge/src/main/java/ru/tinkoff/qa/neptune/allure/jupiter/bridge/NeptuneAllureExcludeTest.java
+++ b/allure.jupiter.bridge/src/main/java/ru/tinkoff/qa/neptune/allure/jupiter/bridge/NeptuneAllureExcludeTest.java
@@ -3,24 +3,17 @@ package ru.tinkoff.qa.neptune.allure.jupiter.bridge;
 import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.AllureResultsWriter;
 import io.qameta.allure.FileSystemResultsWriter;
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
 import ru.tinkoff.qa.neptune.allure.lifecycle.NeptuneResultWriter;
 
 import java.nio.file.Paths;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
 
 import static io.qameta.allure.Allure.setLifecycle;
 import static io.qameta.allure.util.PropertiesUtils.loadAllureProperties;
-import static java.util.Optional.ofNullable;
 
 public class NeptuneAllureExcludeTest implements TestExecutionListener {
 
     private static final NeptuneResultWriter NEPTUNE_RESULT_WRITER = init();
-    private static final ThreadLocal<LinkedHashSet<Class<?>>> TEST_CLASS_THREAD_LOCAL = new ThreadLocal<>();
 
     private static NeptuneResultWriter init() {
         var properties = loadAllureProperties();
@@ -34,49 +27,5 @@ public class NeptuneAllureExcludeTest implements TestExecutionListener {
 
     static void changeResultWriter(AllureResultsWriter writer) {
         NEPTUNE_RESULT_WRITER.setResultWriter(writer);
-    }
-
-    @Override
-    public void executionStarted(final TestIdentifier testIdentifier) {
-        var source = testIdentifier.getSource().orElse(null);
-
-        if (source instanceof ClassSource) {
-            var clazz = ((ClassSource) source).getJavaClass();
-            var queue = ofNullable(TEST_CLASS_THREAD_LOCAL.get()).orElseGet(() -> {
-                var newQueue = new LinkedHashSet<Class<?>>();
-                TEST_CLASS_THREAD_LOCAL.set(newQueue);
-                return newQueue;
-            });
-
-            if (queue.isEmpty() || !queue.contains(clazz)) {
-                queue.add(clazz);
-            }
-        }
-    }
-
-    @Override
-    public void executionFinished(final TestIdentifier testIdentifier,
-                                  final TestExecutionResult testExecutionResult) {
-        var source = testIdentifier.getSource().orElse(null);
-
-        if (source instanceof ClassSource) {
-            var queue = TEST_CLASS_THREAD_LOCAL.get();
-            if (!queue.isEmpty()) {
-                queue.remove(((ClassSource) source).getJavaClass());
-            }
-
-            if (queue.isEmpty()) {
-                TEST_CLASS_THREAD_LOCAL.remove();
-            }
-        }
-    }
-
-    public static Class<?> getCurrentTestClass() {
-        return ofNullable(TEST_CLASS_THREAD_LOCAL.get()).map(set -> {
-            if (set.isEmpty()) {
-                return null;
-            }
-            return new LinkedList<>(set).getLast();
-        }).orElse(null);
     }
 }

--- a/allure.jupiter.bridge/src/test/resources/junit-platform.properties
+++ b/allure.jupiter.bridge/src/test/resources/junit-platform.properties
@@ -1,4 +1,4 @@
 junit.jupiter.extensions.autodetection.enabled=true
 junit.jupiter.execution.parallel.enabled=true
-junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.mode.default=concurrent
 junit.jupiter.execution.parallel.config.dynamic.factor=5

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    globalVersion = '0.24.0-ALPHA'
+    globalVersion = '0.24.1-ALPHA'
 }
 
 repositories {


### PR DESCRIPTION
# Bug description

```java
java.lang.NullPointerException: Cannot invoke "java.lang.Class.getPackage()" because "toExclude" is null
	at ru.tinkoff.qa.neptune.allure.lifecycle.ItemsToNotBeReported.isClassExcluded(ItemsToNotBeReported.java:101)
	at ru.tinkoff.qa.neptune.allure.lifecycle.ItemsToNotBeReported.lambda$excludeIfNecessary$3(ItemsToNotBeReported.java:80)
	at ru.tinkoff.qa.neptune.allure.lifecycle.LifeCycleItemItemStorage.check(LifeCycleItemItemStorage.java:36)
	at ru.tinkoff.qa.neptune.allure.lifecycle.LifeCycleItemItemStorage.setCheck(LifeCycleItemItemStorage.java:
```

## Steps to reproduce

1. In `junit-platform.properties` add

```properties
junit.jupiter.execution.parallel.mode.default = concurrent
```

2. Run tests


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires new tests
- [ ] This change requires correction of current tests

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have actualized tests to prove my fix is effective
- [ ] I have marked code that should be removed `@Deprecated` (if there are breaking changes)