### PR TITLE
0.24.7-ALPHA: improved serialization of ConsumerRecord

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    globalVersion = '0.24.6-ALPHA'
+    globalVersion = '0.24.7-ALPHA'
 }
 
 repositories {

--- a/kafka/src/main/java/ru/tinkoff/qa/neptune/kafka/captors/KafkaValueCaptor.java
+++ b/kafka/src/main/java/ru/tinkoff/qa/neptune/kafka/captors/KafkaValueCaptor.java
@@ -1,6 +1,7 @@
 package ru.tinkoff.qa.neptune.kafka.captors;
 
-import com.google.gson.GsonBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 interface KafkaValueCaptor {
 
@@ -9,7 +10,12 @@ interface KafkaValueCaptor {
         if (caught instanceof String) {
             value = (String) caught;
         } else {
-            value = new GsonBuilder().setPrettyPrinting().create().toJson(caught);
+            try {
+                value = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(caught);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                return null;
+            }
         }
         return new StringBuilder(value);
     }

--- a/kafka/src/main/java/ru/tinkoff/qa/neptune/kafka/jackson/desrializer/ConsumerRecordSerializer.java
+++ b/kafka/src/main/java/ru/tinkoff/qa/neptune/kafka/jackson/desrializer/ConsumerRecordSerializer.java
@@ -1,0 +1,59 @@
+package ru.tinkoff.qa.neptune.kafka.jackson.desrializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import static java.util.Objects.nonNull;
+import static java.util.Optional.ofNullable;
+
+@SuppressWarnings("rawtypes")
+public class ConsumerRecordSerializer extends JsonSerializer<ConsumerRecord> {
+
+    private void writeSerializedProperty(String property,
+                                         JsonGenerator gen,
+                                         ConsumerRecord<?, ?> consumerRecord,
+                                         Function<ConsumerRecord<?, ?>, Object> getPropertyValue) throws IOException {
+        var recordProperty = ofNullable(getPropertyValue.apply(consumerRecord))
+            .map(o -> {
+                try {
+                    return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(o);
+                } catch (Exception e) {
+                    return property + " was not successfully deserialized because of: " + e.getClass() + " " + e.getMessage();
+                }
+            })
+            .orElse(null);
+
+        gen.writeStringField(property, recordProperty);
+    }
+
+    @Override
+    public void serialize(ConsumerRecord value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField("topic", value.topic());
+        gen.writeNumberField("partition", value.partition());
+        value.leaderEpoch().ifPresent(epoch -> {
+            try {
+                gen.writeNumberField("leaderEpoch", (Integer) epoch);
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e);
+            }
+        });
+        gen.writeNumberField("offset", value.offset());
+        if (nonNull(value.timestampType())) {
+            gen.writeObjectField(value.timestampType().toString(), value.timestamp());
+        }
+        serializers.findValueSerializer(Headers.class).serialize(value.headers(), gen, serializers);
+
+        writeSerializedProperty("key", gen, value, ConsumerRecord::key);
+        writeSerializedProperty("value", gen, value, ConsumerRecord::value);
+
+        gen.writeEndObject();
+    }
+}

--- a/kafka/src/main/java/ru/tinkoff/qa/neptune/kafka/jackson/desrializer/HeaderJsonSerializer.java
+++ b/kafka/src/main/java/ru/tinkoff/qa/neptune/kafka/jackson/desrializer/HeaderJsonSerializer.java
@@ -1,0 +1,31 @@
+package ru.tinkoff.qa.neptune.kafka.jackson.desrializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.kafka.common.header.Headers;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static java.util.Objects.isNull;
+
+public class HeaderJsonSerializer extends JsonSerializer<Headers> {
+
+    @Override
+    public void serialize(Headers value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+
+        if (isNull(value)) {
+            return;
+        }
+
+        var headerMap = new LinkedHashMap<String, Set<String>>();
+        value.forEach(header -> {
+            var set = headerMap.computeIfAbsent(header.key(), s -> new LinkedHashSet<>());
+            set.add(new String(header.value()));
+        });
+        gen.writeObjectField("headers", headerMap);
+    }
+}

--- a/kafka/src/main/java/ru/tinkoff/qa/neptune/kafka/jackson/desrializer/KafkaJacksonModule.java
+++ b/kafka/src/main/java/ru/tinkoff/qa/neptune/kafka/jackson/desrializer/KafkaJacksonModule.java
@@ -1,0 +1,13 @@
+package ru.tinkoff.qa.neptune.kafka.jackson.desrializer;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+
+public class KafkaJacksonModule extends SimpleModule {
+
+    public KafkaJacksonModule() {
+        addSerializer(Headers.class, new HeaderJsonSerializer());
+        addSerializer(ConsumerRecord.class, new ConsumerRecordSerializer());
+    }
+}

--- a/kafka/src/test/java/ru/tinkoff/qa/neptune/kafka/ConsumerRecordDeserializationTest.java
+++ b/kafka/src/test/java/ru/tinkoff/qa/neptune/kafka/ConsumerRecordDeserializationTest.java
@@ -11,6 +11,7 @@ import ru.tinkoff.qa.neptune.kafka.jackson.desrializer.KafkaJacksonModule;
 import java.util.Date;
 import java.util.Optional;
 
+import static java.nio.ByteBuffer.allocateDirect;
 import static org.apache.kafka.common.record.TimestampType.LOG_APPEND_TIME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -61,11 +62,34 @@ public class ConsumerRecordDeserializationTest {
                 "{\n" +
                     "  \"topic\" : \"testTopic\",\n" +
                     "  \"partition\" : 1,\n" +
+                    "  \"leaderEpoch\" : null,\n" +
                     "  \"offset\" : 1,\n" +
                     "  \"headers\" : { },\n" +
                     "  \"key\" : null,\n" +
                     "  \"value\" : null\n" +
-                    "}"},
+                    "}"
+            },
+
+            {new ConsumerRecord<>("testTopic", 1,
+                1L,
+                new Date().getTime(),
+                null,
+                0,
+                0,
+                allocateDirect(5),
+                allocateDirect(5),
+                new RecordHeaders(),
+                Optional.empty()),
+                "{\n" +
+                    "  \"topic\" : \"testTopic\",\n" +
+                    "  \"partition\" : 1,\n" +
+                    "  \"leaderEpoch\" : null,\n" +
+                    "  \"offset\" : 1,\n" +
+                    "  \"headers\" : { },\n" +
+                    "  \"key\" : \"\\\"AAAAAAA=\\\"\",\n" +
+                    "  \"value\" : \"\\\"AAAAAAA=\\\"\"\n" +
+                    "}"
+            },
         };
     }
 

--- a/kafka/src/test/java/ru/tinkoff/qa/neptune/kafka/ConsumerRecordDeserializationTest.java
+++ b/kafka/src/test/java/ru/tinkoff/qa/neptune/kafka/ConsumerRecordDeserializationTest.java
@@ -1,0 +1,81 @@
+package ru.tinkoff.qa.neptune.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import ru.tinkoff.qa.neptune.kafka.jackson.desrializer.KafkaJacksonModule;
+
+import java.util.Date;
+import java.util.Optional;
+
+import static org.apache.kafka.common.record.TimestampType.LOG_APPEND_TIME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ConsumerRecordDeserializationTest {
+
+    @DataProvider
+    public static Object[][] data() {
+        var date = new Date();
+        return new Object[][]{
+            {new ConsumerRecord<>("testTopic", 1,
+                1L,
+                date.getTime(),
+                LOG_APPEND_TIME,
+                0,
+                0,
+                new DraftDto().setName("Some Key"),
+                new DraftDto().setName("Some Value"),
+                new RecordHeaders()
+                    .add(new RecordHeader("header1", "value1".getBytes()))
+                    .add(new RecordHeader("header1", "value2".getBytes()))
+                    .add(new RecordHeader("header2", "value1".getBytes())),
+                Optional.of(5)),
+                "{\n" +
+                    "  \"topic\" : \"testTopic\",\n" +
+                    "  \"partition\" : 1,\n" +
+                    "  \"leaderEpoch\" : 5,\n" +
+                    "  \"offset\" : 1,\n" +
+                    "  \"LogAppendTime\" : " + date.getTime() + ",\n" +
+                    "  \"headers\" : {\n" +
+                    "    \"header1\" : [ \"value1\", \"value2\" ],\n" +
+                    "    \"header2\" : [ \"value1\" ]\n" +
+                    "  },\n" +
+                    "  \"key\" : \"{\\n  \\\"name\\\" : \\\"Some Key\\\"\\n}\",\n" +
+                    "  \"value\" : \"{\\n  \\\"name\\\" : \\\"Some Value\\\"\\n}\"\n" +
+                    "}"},
+
+            {new ConsumerRecord<>("testTopic", 1,
+                1L,
+                new Date().getTime(),
+                null,
+                0,
+                0,
+                null,
+                null,
+                new RecordHeaders(),
+                Optional.empty()),
+                "{\n" +
+                    "  \"topic\" : \"testTopic\",\n" +
+                    "  \"partition\" : 1,\n" +
+                    "  \"offset\" : 1,\n" +
+                    "  \"headers\" : { },\n" +
+                    "  \"key\" : null,\n" +
+                    "  \"value\" : null\n" +
+                    "}"},
+        };
+    }
+
+    @Test(dataProvider = "data")
+    public void deserializationTest(ConsumerRecord<?, ?> consumerRecord, String expected) throws Exception {
+        var serialized = new ObjectMapper()
+            .registerModule(new KafkaJacksonModule())
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(consumerRecord);
+
+        assertThat(serialized, is(expected));
+    }
+}

--- a/kafka/src/test/java/ru/tinkoff/qa/neptune/kafka/KafkaBasePreparations.java
+++ b/kafka/src/test/java/ru/tinkoff/qa/neptune/kafka/KafkaBasePreparations.java
@@ -5,6 +5,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -13,10 +15,13 @@ import org.mockito.Mock;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
+import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 import static java.util.List.of;
+import static org.apache.kafka.common.record.TimestampType.LOG_APPEND_TIME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.when;
@@ -109,51 +114,171 @@ public class KafkaBasePreparations {
         var topicPartition = new TopicPartition("testTopic", 1);
         when(consumerWithDeserializedKeyAndValue.poll(any()))
             .thenReturn(new ConsumerRecords<>(Map.of(topicPartition,
-                of(new ConsumerRecord<>("testTopic", 1, 0,
+                of(new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         new DraftDto().setName("Some Key"),
-                        new DraftDto().setName("Some Value")),
-                    new ConsumerRecord<>("testTopic", 1, 0,
+                        new DraftDto().setName("Some Value"),
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5)),
+                    new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         new DraftDto().setName("Some Key2"),
-                        new DraftDto().setName("Some Value2")),
-                    new ConsumerRecord<>("testTopic", 1, 0,
+                        new DraftDto().setName("Some Value2"),
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5)),
+                    new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         null,
-                        null)))));
+                        null,
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5))))));
 
         when(consumerWithDeserializedKey.poll(any()))
             .thenReturn(new ConsumerRecords<>(Map.of(topicPartition,
-                of(new ConsumerRecord<>("testTopic", 1, 0,
+                of(new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         new DraftDto().setName("Some Key"),
-                        "Some String Value 1"),
-                    new ConsumerRecord<>("testTopic", 1, 0,
+                        "Some String Value 1",
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5)),
+                    new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         new DraftDto().setName("Some Key2"),
-                        "Some String Value 2"),
-                    new ConsumerRecord<>("testTopic", 1, 0,
+                        "Some String Value 2",
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5)),
+                    new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         null,
-                        null)))));
+                        null,
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5))))));
 
         when(consumerWithDeserializedValue.poll(any()))
             .thenReturn(new ConsumerRecords<>(Map.of(topicPartition,
-                of(new ConsumerRecord<>("testTopic", 1, 0,
+                of(new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         "Some String Key 1",
-                        new DraftDto().setName("Some Value")),
-                    new ConsumerRecord<>("testTopic", 1, 0,
+                        new DraftDto().setName("Some Value"),
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5)),
+                    new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         "Some String Key 2",
-                        new DraftDto().setName("Some Value2")),
-                    new ConsumerRecord<>("testTopic", 1, 0,
+                        new DraftDto().setName("Some Value2"),
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5)),
+                    new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         null,
-                        null)))));
+                        null,
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5))))));
 
         when(consumerRaw.poll(any()))
             .thenReturn(new ConsumerRecords<>(Map.of(topicPartition,
-                of(new ConsumerRecord<>("testTopic", 1, 0,
+                of(new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         "Some String Key 1",
-                        "Some String Value 1"),
-                    new ConsumerRecord<>("testTopic", 1, 0,
+                        "Some String Value 1",
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5)),
+                    new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         "Some String Key 2",
-                        "Some String Value 2"),
-                    new ConsumerRecord<>("testTopic", 1, 0,
+                        "Some String Value 2",
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5)),
+                    new ConsumerRecord<>("testTopic", 1,
+                        1L,
+                        new Date().getTime(),
+                        LOG_APPEND_TIME,
+                        0,
+                        0,
                         null,
-                        null)))));
+                        null,
+                        new RecordHeaders()
+                            .add(new RecordHeader("header1", "value1".getBytes()))
+                            .add(new RecordHeader("header1", "value2".getBytes()))
+                            .add(new RecordHeader("header2", "value1".getBytes())),
+                        Optional.of(5))))));
     }
 
     @BeforeMethod

--- a/kafka/src/test/java/ru/tinkoff/qa/neptune/kafka/captors/SendMessageTest.java
+++ b/kafka/src/test/java/ru/tinkoff/qa/neptune/kafka/captors/SendMessageTest.java
@@ -19,7 +19,7 @@ public class SendMessageTest extends BaseCaptorTest {
             .topic("Test"));
 
         assertThat(CAUGHT_MESSAGES, mapOf(mapEntry("Producer Record Value", "{\n" +
-            "  \"name\": \"test\"\n" +
+            "  \"name\" : \"test\"\n" +
             "}")));
     }
 
@@ -33,7 +33,7 @@ public class SendMessageTest extends BaseCaptorTest {
         assertThat(CAUGHT_MESSAGES, mapOf(
             mapEntry("Producer Record Key", "Some key"),
             mapEntry("Producer Record Value", "{\n" +
-                "  \"name\": \"test\"\n" +
+                "  \"name\" : \"test\"\n" +
                 "}")));
     }
 }


### PR DESCRIPTION
# Bug description

```Failed making field 'java.nio.ByteBuffer#hb' accessible; either change its visibility or write a custom TypeAdapter for its declaring type
`com.google.gson.JsonIOException: Failed making field 'java.nio.ByteBuffer#hb' accessible; either change its visibility or write a custom TypeAdapter for its declaring type`

## Steps to reproduce

1. Java 15 or above
2. Attempt to poll records

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change requires new tests
- [ ] This change requires correction of current tests

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have actualized tests to prove my fix is effective
- [ ] I have marked code that should be removed `@Deprecated` (if there are breaking changes)